### PR TITLE
Channel fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ var sftp = require('gulp-sftp');
 var slack = require('gulp-slack')({
     token: '*Your slack token*',
     team: 'foo',
-    channel: 'bar'
+    channel: '#bar'
 });
 
 gulp.task('deploy', function () {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function (param) {
     };
 
     var post = {
-        'chann': param.channel,
+        'channel': param.channel,
         'username': param.user || 'Gulp-Slack',
         'text': 'No Text',
         'icon_emoji': ':neckbeard:'
@@ -27,7 +27,7 @@ module.exports = function (param) {
 
         request(options, function (error, response, body) {
             if (!error && response.statusCode === 200) {
-                gutil.log(PLUGIN_NAME + ':', 'Posted update to', gutil.colors.green(post['chann']));
+                gutil.log(PLUGIN_NAME + ':', 'Posted update to', gutil.colors.green(post['channel']));
             } else if (!error) {
                 gutil.log(PLUGIN_NAME + ':', gutil.colors.red(response.statusCode + ' - Something went wrong'));
             } else if (error) {


### PR DESCRIPTION
Posting to a specific channel does not work unless the data is sent as
a ‘channel’ attribute, not ‘chann’. Also updated the readme to suggest
that channels should be prepended with #.
