### PR TITLE
Add support for attachments

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,13 @@ module.exports = function (param) {
     };
 
 
-    var writeTextToSlack = function (text) {
+    var writeTextToSlack = function (text, attachments) {
 
         post['text'] = text || 'No Text';
+
+        if (attachments) {
+            post['attachments'] = attachments;
+        }
 
         options.body = JSON.stringify(post);
 


### PR DESCRIPTION
Slack webhooks also support richly formatted messages in the form of
attachments. This allows them to be passed in optionally as the second
parameter.
