### PR TITLE
Add optional support for icon url

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ var slack = require('gulp-slack')({
     token: '*Your slack token*',
     team: 'foo',
     channel: '#bar',
+    icon_url: 'http://foo.com/bar.jpg', // optional
     icon_emoji: ':bowtie:'
 });
 

--- a/index.js
+++ b/index.js
@@ -17,9 +17,14 @@ module.exports = function (param) {
 
     var basePost = {
         'channel': param.channel,
-        'username': param.user || 'Gulp-Slack',
-        'icon_emoji': param.icon_emoji || ':neckbeard:'
+        'username': param.user || 'Gulp-Slack'
     };
+
+    if (param.icon_url) {
+        basePost.icon_url = param.icon_url;
+    } else {
+        basePost.icon_emoji: param.icon_emoji || ':neckbeard:'
+    }
 
 
     var writeTextToSlack = function (input) {


### PR DESCRIPTION
This adds the optional ability to pass `icon_url` in order to use an icon url instead of an icon emoji.